### PR TITLE
Select loopback traffic by port and not by address.

### DIFF
--- a/lpfw.cpp
+++ b/lpfw.cpp
@@ -2235,8 +2235,8 @@ void init_iptables()
   //using /mask caused 10+ second lag when calling iptables
   //_system ("iptables -I OUTPUT 1 -d 127.0.0.0/8 -j ACCEPT");
   //_system ("iptables -I INPUT 1 -d 127.0.0.0/8 -j ACCEPT");
-  _system ("iptables -I OUTPUT 1 -m iprange --dst-range 127.0.0.0-127.255.255.255 -j ACCEPT");
-  _system ("iptables -I INPUT 1 -m iprange --dst-range 127.0.0.0-127.255.255.255 -j ACCEPT");
+  _system ("iptables -I OUTPUT 1 -o lo -j ACCEPT");
+  _system ("iptables -I INPUT 1 -i lo -j ACCEPT");
 
 
   //save and start checking if iptables rules altered


### PR DESCRIPTION
* '-o lo' and '-i lo' is the default of all Linux firewall
  configurations I know. Not sure why one would go with something else
  for that.